### PR TITLE
fix: prevent observer exit on empty observations file

### DIFF
--- a/scripts/observer-agent.sh
+++ b/scripts/observer-agent.sh
@@ -84,7 +84,8 @@ if [ -f "$OBSERVER_LOCK" ]; then
 fi
 echo $$ > "$OBSERVER_LOCK"
 TMPMSGS=""
-trap 'rm -f "$OBSERVER_LOCK" "$TMPMSGS" 2>/dev/null' EXIT
+MSGS_TMP=""
+trap 'rm -f "$OBSERVER_LOCK" "$TMPMSGS" "$MSGS_TMP" 2>/dev/null' EXIT
 
 # --- Determine lookback window ---
 FLUSH_MODE=false
@@ -201,7 +202,6 @@ if [ -z "${LLM_API_KEY:-}" ]; then
 fi
 
 # --- Call LLM (with existing observations context for dedup) ---
-SYSTEM_PROMPT=$(cat "$OBSERVER_PROMPT")
 TODAY=$(date '+%Y-%m-%d')
 
 # Feed last 30 lines of existing observations so LLM avoids repeating them
@@ -210,14 +210,18 @@ if [ -f "$OBSERVATIONS_FILE" ]; then
   EXISTING_TAIL=$(tail -80 "$OBSERVATIONS_FILE" | grep -E '^\s*-\s*[🔴🟡🟢]' | tail -40 || true)
 fi
 
-DEDUP_CONTEXT=""
-if [ -n "$EXISTING_TAIL" ]; then
-  DEDUP_CONTEXT="\n\n## Already Recorded (DO NOT repeat these — they are already in memory)\n$EXISTING_TAIL"
-fi
+# Write user content to temp file (avoids jq --arg issues with special chars in messages)
+MSGS_TMP=$(mktemp)
+{
+  printf 'Today is %s. Compress these recent messages into observations:\n\n%s' "$TODAY" "$RECENT_MESSAGES"
+  if [ -n "$EXISTING_TAIL" ]; then
+    printf '\n\n## Already Recorded (DO NOT repeat these — they are already in memory)\n%s' "$EXISTING_TAIL"
+  fi
+} > "$MSGS_TMP"
 
 PAYLOAD=$(jq -n \
-  --arg system "$SYSTEM_PROMPT" \
-  --arg messages "Today is $TODAY. Compress these recent messages into observations:\n\n$RECENT_MESSAGES$DEDUP_CONTEXT" \
+  --rawfile system "$OBSERVER_PROMPT" \
+  --rawfile messages "$MSGS_TMP" \
   '{
     model: "placeholder",
     messages: [
@@ -227,6 +231,7 @@ PAYLOAD=$(jq -n \
     max_tokens: 2000,
     temperature: 0.3
   }')
+rm -f "$MSGS_TMP"
 
 log "DEBUG: LLM_MODEL is $LLM_MODEL"
 log "DEBUG: OBSERVER_MODEL is $OBSERVER_MODEL"


### PR DESCRIPTION
## Summary

- Observer script exits with code 1 when `observations.md` has no emoji bullet lines (e.g. fresh file with only header + `---`)
- Root cause: `grep -E '^\s*-\s*[🔴🟡🟢]'` returns exit code 1 when no matches, and `set -euo pipefail` propagates this through the pipeline, killing the script
- Added `|| true` to two grep pipelines (line 210: dedup context, line 272: fingerprint extraction) so empty results reach the existing downstream guards instead of crashing

## Test plan

- [ ] Start with an empty/header-only `observations.md` — observer should complete successfully and write new observations
- [ ] Start with a populated `observations.md` — dedup behavior unchanged, existing bullet lines still detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a model retry mechanism with a fallback to improve reliability of observation generation.
  * Added deduplication of observations after analysis to avoid reporting duplicates.

* **Bug Fixes**
  * Prevents premature termination when no prior fingerprints or matches exist, improving robustness in edge cases.
  * Ensures temporary payloads are cleaned up and improves logging for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->