### PR TITLE
fix: per-agent workspace locks + dream-cycle favorites.md auto-create

### DIFF
--- a/scripts/dream-cycle.sh
+++ b/scripts/dream-cycle.sh
@@ -98,7 +98,7 @@ cmd_preflight() {
   fi
 
   require_file "$OBSERVATIONS_FILE"
-  require_file "$FAVORITES_FILE"
+  [ -f "$FAVORITES_FILE" ] || { mkdir -p "$MEMORY_DIR"; printf "# Favorites\n\n(No favorites recorded yet.)\n" > "$FAVORITES_FILE"; }
   ensure_dirs
 
   local backup_file="$BACKUP_DIR/observations.pre-dream.md"

--- a/scripts/observer-agent.sh
+++ b/scripts/observer-agent.sh
@@ -29,7 +29,7 @@ OBSERVER_PROMPT="$SKILL_DIR/prompts/observer-system.txt"
 OBSERVER_LOG="$WORKSPACE/logs/observer.log"
 MARKER_FILE="$MEMORY_DIR/.observer-last-run"
 HASH_FILE="$MEMORY_DIR/.observer-last-hash"
-LOCK_FILE="/tmp/total-recall-reflector-$(id -u).lock"
+LOCK_FILE="$WORKSPACE/logs/reflector.lock"
 
 # Source env if available (grep-guard: only export KEY=VALUE lines)
 if [ -f "$WORKSPACE/.env" ]; then
@@ -61,7 +61,7 @@ if [ ! -f "$OBSERVER_PROMPT" ]; then
 fi
 
 # --- Lock check (prevent collision with reflector OR another observer) ---
-OBSERVER_LOCK="/tmp/total-recall-observer-$(id -u).lock"
+OBSERVER_LOCK="$WORKSPACE/logs/observer.lock"
 if [ -f "$LOCK_FILE" ]; then
   LOCK_AGE=$(( $(date +%s) - $(file_mtime "$LOCK_FILE") ))
   if [ "$LOCK_AGE" -lt 300 ]; then

--- a/scripts/reflector-agent.sh
+++ b/scripts/reflector-agent.sh
@@ -23,7 +23,7 @@ OBSERVATIONS_FILE="$MEMORY_DIR/observations.md"
 REFLECTOR_PROMPT="$SKILL_DIR/prompts/reflector-system.txt"
 REFLECTOR_LOG="$WORKSPACE/logs/reflector.log"
 BACKUP_DIR="$MEMORY_DIR/observation-backups"
-LOCK_FILE="/tmp/total-recall-reflector-$(id -u).lock"
+LOCK_FILE="$WORKSPACE/logs/reflector.lock"
 
 # Safe env loading
 if [ -f "$WORKSPACE/.env" ]; then


### PR DESCRIPTION
## Problem

Two bugs that affect multi-agent Total Recall deployments:

### Bug 1: Multi-agent lock collision (observer/reflector)

When multiple agents run Total Recall under the same OS user (e.g. `main`, `atlas`, `conductor` all running as `jared`), they share the same lock files:

```
/tmp/total-recall-observer-<uid>.lock
/tmp/total-recall-reflector-<uid>.lock
```

This means whichever agent grabs the lock first blocks all other agents from running for the duration. In practice, 2 out of 3 agents' observers **always skip** — they see the first agent's lock and bail out. The result is `observations.md` never gets populated for those agents.

### Bug 2: Dream cycle preflight fails on first run

`dream-cycle.sh preflight` calls `require_file "$FAVORITES_FILE"` which hard-fails if `favorites.md` doesn't exist. On a fresh install before the first dream cycle has ever run, this file doesn't exist yet — so the very first nightly run errors out immediately.

## Fix

**Bug 1:** Move both lock files into `$WORKSPACE/logs/` which is already agent-specific (set via `OPENCLAW_WORKSPACE` env). Each agent now has its own `observer.lock` and `reflector.lock`.

**Bug 2:** Auto-create `favorites.md` with an empty template if it doesn't exist, instead of hard-failing.

## Testing

Verified on a 3-agent deployment (main/atlas/conductor). Before fix: only 1 of 3 observers ever ran. After fix: all 3 run independently every 15 minutes without interference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Favorites file now auto-initializes with default settings on first use, eliminating initialization errors.

* **Bug Fixes**
  * Improved lock management reliability by using workspace-specific paths for better stability and isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->