### PR TITLE
Add macOS compatibility helpers to _compat.sh

### DIFF
--- a/scripts/_compat.sh
+++ b/scripts/_compat.sh
@@ -159,8 +159,8 @@ portable_flock() {
     _prev_term_cmd=$(trap -p TERM | sed "s/^trap -- '//;s/' TERM$//" 2>/dev/null)
     trap "rm -rf \"$lock_dir\"; ${_prev_int_cmd:-:}; exit 130" INT
     trap "rm -rf \"$lock_dir\"; ${_prev_term_cmd:-:}; exit 143" TERM
-    "$@"
-    local rc=$?
+    local rc=0
+    "$@" || rc=$?
     # Restore original traps
     if [[ -n "$_prev_int_cmd" ]]; then eval "trap -- '$_prev_int_cmd' INT"; else trap - INT; fi
     if [[ -n "$_prev_term_cmd" ]]; then eval "trap -- '$_prev_term_cmd' TERM"; else trap - TERM; fi
@@ -213,9 +213,16 @@ bus_append() {
       sleep 0.1
     done
     echo $$ > "${lock_dir}/pid" 2>/dev/null
-    trap "rm -rf \"$lock_dir\"" INT TERM
+    # Save existing signal traps before overwriting
+    local _prev_int_cmd _prev_term_cmd
+    _prev_int_cmd=$(trap -p INT | sed "s/^trap -- '//;s/' INT$//" 2>/dev/null)
+    _prev_term_cmd=$(trap -p TERM | sed "s/^trap -- '//;s/' TERM$//" 2>/dev/null)
+    trap "rm -rf \"$lock_dir\"; ${_prev_int_cmd:-:}; exit 130" INT
+    trap "rm -rf \"$lock_dir\"; ${_prev_term_cmd:-:}; exit 143" TERM
     printf '%s\n' "$data" >> "$target"
-    trap - INT TERM
+    # Restore original traps
+    if [[ -n "$_prev_int_cmd" ]]; then eval "trap -- '$_prev_int_cmd' INT"; else trap - INT; fi
+    if [[ -n "$_prev_term_cmd" ]]; then eval "trap -- '$_prev_term_cmd' TERM"; else trap - TERM; fi
     rm -rf "$lock_dir"
   fi
 }
@@ -227,7 +234,11 @@ try_lock() {
   local lockfile="$1" fd="${2:-9}"
   if command -v flock &>/dev/null; then
     eval "exec ${fd}>\"${lockfile}\""
-    flock -n "$fd" 2>/dev/null
+    if ! flock -n "$fd" 2>/dev/null; then
+      # Lock held by another process — close fd and report failure
+      eval "exec ${fd}>&-" 2>/dev/null
+      return 1
+    fi
     # Store fd so release_lock can close it
     _OPENCLAW_LOCK_FD="$fd"
   else

--- a/scripts/_compat.sh
+++ b/scripts/_compat.sh
@@ -36,7 +36,7 @@ date_days_ago() {
   if $_IS_MACOS; then
     date -u -v "-${days}d" '+%Y-%m-%d'
   else
-    date -d "-${days} days" '+%Y-%m-%d' 2>/dev/null || echo ""
+    date -u -d "-${days} days" '+%Y-%m-%d' 2>/dev/null || echo ""
   fi
 }
 
@@ -46,7 +46,7 @@ date_days_ahead() {
   if $_IS_MACOS; then
     date -u -v "+${days}d" '+%Y-%m-%d'
   else
-    date -d "+${days} days" '+%Y-%m-%d' 2>/dev/null || echo ""
+    date -u -d "+${days} days" '+%Y-%m-%d' 2>/dev/null || echo ""
   fi
 }
 
@@ -146,16 +146,16 @@ portable_flock() {
       sleep 0.1
     done
     # Save existing signal traps before overwriting
-    local _prev_int _prev_term
-    _prev_int=$(trap -p INT)
-    _prev_term=$(trap -p TERM)
-    trap "rm -rf \"$lock_dir\"; ${_prev_int:-:}; exit 130" INT
-    trap "rm -rf \"$lock_dir\"; ${_prev_term:-:}; exit 143" TERM
+    local _prev_int_cmd _prev_term_cmd
+    _prev_int_cmd=$(trap -p INT | sed "s/^trap -- '//;s/' INT$//" 2>/dev/null)
+    _prev_term_cmd=$(trap -p TERM | sed "s/^trap -- '//;s/' TERM$//" 2>/dev/null)
+    trap "rm -rf \"$lock_dir\"; ${_prev_int_cmd:-:}; exit 130" INT
+    trap "rm -rf \"$lock_dir\"; ${_prev_term_cmd:-:}; exit 143" TERM
     "$@"
     local rc=$?
-    # Restore previous traps
-    if [[ -n "$_prev_int" ]]; then eval "$_prev_int"; else trap - INT; fi
-    if [[ -n "$_prev_term" ]]; then eval "$_prev_term"; else trap - TERM; fi
+    # Restore original traps
+    if [[ -n "$_prev_int_cmd" ]]; then eval "trap -- '$_prev_int_cmd' INT"; else trap - INT; fi
+    if [[ -n "$_prev_term_cmd" ]]; then eval "trap -- '$_prev_term_cmd' TERM"; else trap - TERM; fi
     rm -rf "$lock_dir"
     return $rc
   fi
@@ -208,11 +208,11 @@ try_lock() {
       return 1
     fi
     # Ensure lock dir is cleaned up on signals
-    local _prev_int _prev_term
-    _prev_int=$(trap -p INT)
-    _prev_term=$(trap -p TERM)
-    trap "rm -rf \"$lock_dir\"; ${_prev_int:-:}; exit 130" INT
-    trap "rm -rf \"$lock_dir\"; ${_prev_term:-:}; exit 143" TERM
+    # Store in module-level vars so release_lock can restore them
+    _OPENCLAW_LOCK_PREV_INT=$(trap -p INT | sed "s/^trap -- '//;s/' INT$//" 2>/dev/null)
+    _OPENCLAW_LOCK_PREV_TERM=$(trap -p TERM | sed "s/^trap -- '//;s/' TERM$//" 2>/dev/null)
+    trap "rm -rf \"$lock_dir\"; ${_OPENCLAW_LOCK_PREV_INT:-:}; exit 130" INT
+    trap "rm -rf \"$lock_dir\"; ${_OPENCLAW_LOCK_PREV_TERM:-:}; exit 143" TERM
   fi
 }
 
@@ -224,6 +224,18 @@ release_lock() {
   local lockfile="$1"
   if ! command -v flock &>/dev/null; then
     rm -rf "${lockfile}.d"
+    # Restore original signal traps
+    if [[ -n "${_OPENCLAW_LOCK_PREV_INT:-}" ]]; then
+      eval "trap -- '$_OPENCLAW_LOCK_PREV_INT' INT"
+    else
+      trap - INT
+    fi
+    if [[ -n "${_OPENCLAW_LOCK_PREV_TERM:-}" ]]; then
+      eval "trap -- '$_OPENCLAW_LOCK_PREV_TERM' TERM"
+    else
+      trap - TERM
+    fi
+    unset _OPENCLAW_LOCK_PREV_INT _OPENCLAW_LOCK_PREV_TERM
   fi
 }
 

--- a/scripts/_compat.sh
+++ b/scripts/_compat.sh
@@ -136,16 +136,26 @@ portable_flock() {
       if ((retries > 50)); then
         # Stale lock — remove and retry
         rm -rf "$lock_dir"
-        mkdir "$lock_dir" 2>/dev/null || true
-        break
+        if mkdir "$lock_dir" 2>/dev/null; then
+          break
+        fi
+        # Another process grabbed it — keep waiting
+        retries=0
+        continue
       fi
       sleep 0.1
     done
-    # Ensure lock dir is cleaned up on signals (Ctrl+C, kill, etc.)
-    trap 'rm -rf "$lock_dir"' INT TERM
+    # Save existing signal traps before overwriting
+    local _prev_int _prev_term
+    _prev_int=$(trap -p INT)
+    _prev_term=$(trap -p TERM)
+    trap "rm -rf \"$lock_dir\"; ${_prev_int:-:}; exit 130" INT
+    trap "rm -rf \"$lock_dir\"; ${_prev_term:-:}; exit 143" TERM
     "$@"
     local rc=$?
-    trap - INT TERM
+    # Restore previous traps
+    if [[ -n "$_prev_int" ]]; then eval "$_prev_int"; else trap - INT; fi
+    if [[ -n "$_prev_term" ]]; then eval "$_prev_term"; else trap - TERM; fi
     rm -rf "$lock_dir"
     return $rc
   fi
@@ -158,8 +168,11 @@ portable_flock() {
 portable_flock_fd() {
   if command -v flock &>/dev/null; then
     flock -x "$1"
+  else
+    # macOS without flock: warn caller so they know locking is not happening
+    echo "[_compat] WARNING: portable_flock_fd is a no-op on macOS (no flock). Use portable_flock instead." >&2
+    return 1
   fi
-  # On macOS without flock: no-op, caller must use portable_flock wrapper
 }
 
 # Atomically append a line to a file with exclusive locking (portable)
@@ -191,7 +204,26 @@ try_lock() {
     flock -n "$fd" 2>/dev/null
   else
     local lock_dir="${lockfile}.d"
-    mkdir "$lock_dir" 2>/dev/null
+    if ! mkdir "$lock_dir" 2>/dev/null; then
+      return 1
+    fi
+    # Ensure lock dir is cleaned up on signals
+    local _prev_int _prev_term
+    _prev_int=$(trap -p INT)
+    _prev_term=$(trap -p TERM)
+    trap "rm -rf \"$lock_dir\"; ${_prev_int:-:}; exit 130" INT
+    trap "rm -rf \"$lock_dir\"; ${_prev_term:-:}; exit 143" TERM
+  fi
+}
+
+# Release a lock acquired by try_lock (portable)
+# Usage: release_lock <lockfile>
+# On Linux with flock this is a no-op (lock auto-releases on fd close).
+# On macOS this removes the mkdir-based lock directory.
+release_lock() {
+  local lockfile="$1"
+  if ! command -v flock &>/dev/null; then
+    rm -rf "${lockfile}.d"
   fi
 }
 

--- a/scripts/_compat.sh
+++ b/scripts/_compat.sh
@@ -64,9 +64,9 @@ date_hours_ago() {
 iso_to_epoch() {
   local iso="$1"
   if $_IS_MACOS; then
-    # Strip trailing Z, parse with -jf
+    # Strip trailing Z, parse as UTC with -juf
     local clean="${iso%Z}"
-    date -jf '%Y-%m-%dT%H:%M:%S' "$clean" '+%s' 2>/dev/null || echo ""
+    date -juf '%Y-%m-%dT%H:%M:%S' "$clean" '+%s' 2>/dev/null || echo ""
   else
     date -u -d "$iso" '+%s' 2>/dev/null || echo ""
   fi
@@ -76,7 +76,7 @@ iso_to_epoch() {
 iso_date_to_epoch() {
   local iso="$1"
   if $_IS_MACOS; then
-    date -jf '%Y-%m-%d' "$iso" '+%s' 2>/dev/null || echo 0
+    date -juf '%Y-%m-%d' "$iso" '+%s' 2>/dev/null || echo 0
   else
     date -d "$iso" '+%s' 2>/dev/null || echo 0
   fi
@@ -134,7 +134,14 @@ portable_flock() {
     while ! mkdir "$lock_dir" 2>/dev/null; do
       retries=$((retries + 1))
       if ((retries > 50)); then
-        # Stale lock — remove and retry
+        # Stale lock — check if owner PID is still alive
+        local owner_pid
+        owner_pid=$(cat "${lock_dir}/pid" 2>/dev/null)
+        if [[ -n "$owner_pid" ]] && kill -0 "$owner_pid" 2>/dev/null; then
+          # Owner is alive — keep waiting
+          retries=0
+          continue
+        fi
         rm -rf "$lock_dir"
         if mkdir "$lock_dir" 2>/dev/null; then
           break
@@ -145,6 +152,7 @@ portable_flock() {
       fi
       sleep 0.1
     done
+    echo $$ > "${lock_dir}/pid" 2>/dev/null
     # Save existing signal traps before overwriting
     local _prev_int_cmd _prev_term_cmd
     _prev_int_cmd=$(trap -p INT | sed "s/^trap -- '//;s/' INT$//" 2>/dev/null)
@@ -186,10 +194,28 @@ bus_append() {
     local retries=0
     while ! mkdir "$lock_dir" 2>/dev/null; do
       retries=$((retries + 1))
-      if ((retries > 50)); then rm -rf "$lock_dir"; mkdir "$lock_dir" 2>/dev/null || true; break; fi
+      if ((retries > 50)); then
+        # Stale lock — check if owner PID is still alive
+        local owner_pid
+        owner_pid=$(cat "${lock_dir}/pid" 2>/dev/null)
+        if [[ -n "$owner_pid" ]] && kill -0 "$owner_pid" 2>/dev/null; then
+          # Owner is alive — keep waiting
+          retries=0
+          continue
+        fi
+        rm -rf "$lock_dir"
+        if mkdir "$lock_dir" 2>/dev/null; then
+          break
+        fi
+        retries=0
+        continue
+      fi
       sleep 0.1
     done
+    echo $$ > "${lock_dir}/pid" 2>/dev/null
+    trap "rm -rf \"$lock_dir\"" INT TERM
     printf '%s\n' "$data" >> "$target"
+    trap - INT TERM
     rm -rf "$lock_dir"
   fi
 }
@@ -202,11 +228,14 @@ try_lock() {
   if command -v flock &>/dev/null; then
     eval "exec ${fd}>\"${lockfile}\""
     flock -n "$fd" 2>/dev/null
+    # Store fd so release_lock can close it
+    _OPENCLAW_LOCK_FD="$fd"
   else
     local lock_dir="${lockfile}.d"
     if ! mkdir "$lock_dir" 2>/dev/null; then
       return 1
     fi
+    echo $$ > "${lock_dir}/pid" 2>/dev/null
     # Ensure lock dir is cleaned up on signals
     # Store in module-level vars so release_lock can restore them
     _OPENCLAW_LOCK_PREV_INT=$(trap -p INT | sed "s/^trap -- '//;s/' INT$//" 2>/dev/null)
@@ -217,12 +246,14 @@ try_lock() {
 }
 
 # Release a lock acquired by try_lock (portable)
-# Usage: release_lock <lockfile>
-# On Linux with flock this is a no-op (lock auto-releases on fd close).
-# On macOS this removes the mkdir-based lock directory.
+# Usage: release_lock <lockfile> [fd_num]
+# On Linux: closes the flock fd. On macOS: removes the lock directory.
 release_lock() {
-  local lockfile="$1"
-  if ! command -v flock &>/dev/null; then
+  local lockfile="$1" fd="${2:-${_OPENCLAW_LOCK_FD:-9}}"
+  if command -v flock &>/dev/null; then
+    eval "exec ${fd}>&-" 2>/dev/null
+    unset _OPENCLAW_LOCK_FD
+  else
     rm -rf "${lockfile}.d"
     # Restore original signal traps
     if [[ -n "${_OPENCLAW_LOCK_PREV_INT:-}" ]]; then

--- a/scripts/_compat.sh
+++ b/scripts/_compat.sh
@@ -2,6 +2,11 @@
 # Cross-platform compatibility helpers (Linux + macOS)
 # Sourced by other scripts — not run directly
 
+if [[ -n "${_COMPAT_SH_LOADED:-}" ]]; then
+  return 0
+fi
+readonly _COMPAT_SH_LOADED=1
+
 # Detect OS
 _IS_MACOS=false
 [[ "$(uname -s)" == "Darwin" ]] && _IS_MACOS=true
@@ -25,6 +30,83 @@ date_minutes_ago() {
   fi
 }
 
+# Get date N days ago as YYYY-MM-DD (portable)
+date_days_ago() {
+  local days="$1"
+  if $_IS_MACOS; then
+    date -u -v "-${days}d" '+%Y-%m-%d'
+  else
+    date -d "-${days} days" '+%Y-%m-%d' 2>/dev/null || echo ""
+  fi
+}
+
+# Get date N days ahead as YYYY-MM-DD (portable)
+date_days_ahead() {
+  local days="$1"
+  if $_IS_MACOS; then
+    date -u -v "+${days}d" '+%Y-%m-%d'
+  else
+    date -d "+${days} days" '+%Y-%m-%d' 2>/dev/null || echo ""
+  fi
+}
+
+# Get date N hours ago as ISO UTC (portable)
+date_hours_ago() {
+  local hours="$1"
+  if $_IS_MACOS; then
+    date -u -v "-${hours}H" '+%Y-%m-%dT%H:%M:%SZ'
+  else
+    date -u -d "${hours} hours ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo ""
+  fi
+}
+
+# Convert ISO timestamp to epoch seconds (portable)
+iso_to_epoch() {
+  local iso="$1"
+  if $_IS_MACOS; then
+    # Strip trailing Z, parse with -jf
+    local clean="${iso%Z}"
+    date -jf '%Y-%m-%dT%H:%M:%S' "$clean" '+%s' 2>/dev/null || echo ""
+  else
+    date -u -d "$iso" '+%s' 2>/dev/null || echo ""
+  fi
+}
+
+# Convert ISO date (YYYY-MM-DD) to epoch seconds (portable)
+iso_date_to_epoch() {
+  local iso="$1"
+  if $_IS_MACOS; then
+    date -jf '%Y-%m-%d' "$iso" '+%s' 2>/dev/null || echo 0
+  else
+    date -d "$iso" '+%s' 2>/dev/null || echo 0
+  fi
+}
+
+# Convert date string to ISO UTC (portable, best-effort)
+date_to_iso_utc() {
+  local input="$1"
+  if $_IS_MACOS; then
+    # Try common formats
+    date -juf '%Y-%m-%dT%H:%M:%S%z' "$input" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+      || date -juf '%Y-%m-%dT%H:%M:%SZ' "$input" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+      || echo ""
+  else
+    date -u -d "$input" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo ""
+  fi
+}
+
+# SHA-256 hash of stdin (portable)
+sha256_hash() {
+  if command -v sha256sum &>/dev/null; then
+    sha256sum | awk '{print $1}'
+  elif command -v shasum &>/dev/null; then
+    shasum -a 256 | awk '{print $1}'
+  else
+    # Last resort: openssl
+    openssl dgst -sha256 | awk '{print $NF}'
+  fi
+}
+
 # MD5 hash of stdin (portable)
 md5_hash() {
   if command -v md5sum &>/dev/null; then
@@ -34,6 +116,103 @@ md5_hash() {
   else
     # Last resort: use shasum
     shasum | cut -d' ' -f1
+  fi
+}
+
+# Portable exclusive file lock wrapper
+# Usage: portable_flock <lockfile> <command...>
+# Replaces: ( flock -x 200; cmd ) 200>lockfile
+portable_flock() {
+  local lockfile="$1"
+  shift
+  if command -v flock &>/dev/null; then
+    ( flock -x 200; "$@" ) 200>"$lockfile"
+  else
+    # macOS fallback: mkdir-based atomic lock with retry
+    local lock_dir="${lockfile}.d"
+    local retries=0
+    while ! mkdir "$lock_dir" 2>/dev/null; do
+      retries=$((retries + 1))
+      if ((retries > 50)); then
+        # Stale lock — remove and retry
+        rm -rf "$lock_dir"
+        mkdir "$lock_dir" 2>/dev/null || true
+        break
+      fi
+      sleep 0.1
+    done
+    # Ensure lock dir is cleaned up on signals (Ctrl+C, kill, etc.)
+    trap 'rm -rf "$lock_dir"' INT TERM
+    "$@"
+    local rc=$?
+    trap - INT TERM
+    rm -rf "$lock_dir"
+    return $rc
+  fi
+}
+
+# Portable exclusive flock with file-descriptor redirection
+# Usage: portable_flock_fd <fd_num> <lockfile>
+# For use in: ( portable_flock_fd 200 "$LOCK"; echo "$data" >> "$FILE" ) 200>"$LOCK"
+# On macOS this is a no-op (caller should use portable_flock instead)
+portable_flock_fd() {
+  if command -v flock &>/dev/null; then
+    flock -x "$1"
+  fi
+  # On macOS without flock: no-op, caller must use portable_flock wrapper
+}
+
+# Atomically append a line to a file with exclusive locking (portable)
+# Usage: bus_append <lockfile> <target_file> <data>
+bus_append() {
+  local lockfile="$1" target="$2" data="$3"
+  if command -v flock &>/dev/null; then
+    ( flock -x 200; printf '%s\n' "$data" >> "$target" ) 200>"$lockfile"
+  else
+    local lock_dir="${lockfile}.d"
+    local retries=0
+    while ! mkdir "$lock_dir" 2>/dev/null; do
+      retries=$((retries + 1))
+      if ((retries > 50)); then rm -rf "$lock_dir"; mkdir "$lock_dir" 2>/dev/null || true; break; fi
+      sleep 0.1
+    done
+    printf '%s\n' "$data" >> "$target"
+    rm -rf "$lock_dir"
+  fi
+}
+
+# Non-blocking lock attempt (portable)
+# Usage: if try_lock <lockfile> <fd_num>; then ...; fi
+# Returns 0 if lock acquired, 1 if another instance holds it
+try_lock() {
+  local lockfile="$1" fd="${2:-9}"
+  if command -v flock &>/dev/null; then
+    eval "exec ${fd}>\"${lockfile}\""
+    flock -n "$fd" 2>/dev/null
+  else
+    local lock_dir="${lockfile}.d"
+    mkdir "$lock_dir" 2>/dev/null
+  fi
+}
+
+# Rotate a log file if it exceeds a size limit (default 1MB)
+# Usage: rotate_log <logfile> [max_bytes]
+rotate_log() {
+  local logfile="$1"
+  local max_bytes="${2:-1048576}"  # 1MB default
+  [ -f "$logfile" ] || return 0
+  local size
+  if $_IS_MACOS; then
+    size=$(stat -f %z "$logfile" 2>/dev/null || echo 0)
+  else
+    size=$(stat -c %s "$logfile" 2>/dev/null || echo 0)
+  fi
+  if (( size > max_bytes )); then
+    # Keep last 500 lines, rotate the rest
+    local tmp
+    tmp="$(mktemp)"
+    tail -500 "$logfile" > "$tmp" 2>/dev/null
+    mv "$tmp" "$logfile"
   fi
 }
 

--- a/scripts/aie-config.sh
+++ b/scripts/aie-config.sh
@@ -7,6 +7,8 @@ fi
 readonly AIE_CONFIG_SH_LOADED=1
 
 AIE_CONFIG_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Load cross-platform compat layer (sha256_hash, iso_to_epoch, portable_flock, etc.)
+source "$AIE_CONFIG_SCRIPT_DIR/_compat.sh"
 AIE_REPO_ROOT="$(cd "${AIE_CONFIG_SCRIPT_DIR}/.." && pwd)"
 AIE_DEFAULT_WORKSPACE="${OPENCLAW_WORKSPACE:-$AIE_REPO_ROOT}"
 AIE_CONFIG_FILE="${AIE_CONFIG_FILE:-${AIE_DEFAULT_WORKSPACE}/config/aie.yaml}"

--- a/scripts/aie-config.sh
+++ b/scripts/aie-config.sh
@@ -8,7 +8,8 @@ readonly AIE_CONFIG_SH_LOADED=1
 
 AIE_CONFIG_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Load cross-platform compat layer (sha256_hash, iso_to_epoch, portable_flock, etc.)
-source "$AIE_CONFIG_SCRIPT_DIR/_compat.sh"
+source "$AIE_CONFIG_SCRIPT_DIR/_compat.sh" \
+  || { echo "[aie-config] WARNING: failed to load _compat.sh" >&2; }
 AIE_REPO_ROOT="$(cd "${AIE_CONFIG_SCRIPT_DIR}/.." && pwd)"
 AIE_DEFAULT_WORKSPACE="${OPENCLAW_WORKSPACE:-$AIE_REPO_ROOT}"
 AIE_CONFIG_FILE="${AIE_CONFIG_FILE:-${AIE_DEFAULT_WORKSPACE}/config/aie.yaml}"
@@ -210,7 +211,7 @@ if os.path.exists(config_file):
         raise SystemExit("AIE config must be a YAML mapping at the top level")
     merge(config, loaded)
 
-today = __import__("datetime").datetime.now(__import__("datetime").UTC).strftime("%Y-%m-%d")
+today = __import__("datetime").datetime.now(__import__("datetime").timezone.utc).strftime("%Y-%m-%d")
 config["workspace"] = os.path.abspath(os.path.expanduser(str(config.get("workspace") or workspace)))
 
 def expand_path(value, base_dir):

--- a/scripts/preconscious-select.sh
+++ b/scripts/preconscious-select.sh
@@ -29,7 +29,12 @@ export TMP_NOTES
 trap 'rm -f "$TMP_NOTES"' EXIT
 
 for i in 0 1 2 3 4 5 6; do
-  DAY=$(date -d "-${i} days" +%Y-%m-%d 2>/dev/null || echo "")
+  # Portable date: -d for Linux, -v for macOS
+  if date -d "-${i} days" +%Y-%m-%d >/dev/null 2>&1; then
+    DAY=$(date -d "-${i} days" +%Y-%m-%d)
+  else
+    DAY=$(date -v"-${i}d" +%Y-%m-%d 2>/dev/null || echo "")
+  fi
   [[ -z "$DAY" ]] && continue
   FILE="$RUMINATION_DIR/${DAY}.jsonl"
   [[ -f "$FILE" ]] || continue


### PR DESCRIPTION
## Summary

Addresses #10 — macOS compatibility issues with GNU-only utilities.

- **Include guard** added to `_compat.sh` to prevent double-sourcing
- **Date helpers**: `date_days_ago()`, `date_days_ahead()`, `date_hours_ago()`, `iso_to_epoch()`, `iso_date_to_epoch()`, `date_to_iso_utc()` — all with macOS `date -v`/`-jf` equivalents
- **`sha256_hash()`**: tries `sha256sum` → `shasum -a 256` → `openssl dgst -sha256`
- **`portable_flock()`**: `mkdir`-based atomic lock fallback for macOS (no `flock`). Includes SIGINT/SIGTERM trap to clean up lock dirs on Ctrl+C
- **`bus_append()`**: atomic file append with locking (portable)
- **`try_lock()`**: non-blocking lock attempt (portable)
- **`rotate_log()`**: simple log rotation (keeps last 500 lines when file exceeds size threshold)
- **`aie-config.sh`** now sources `_compat.sh`, so all scripts that go through `aie_init` get the compat layer automatically

## Test plan

- [x] All functions tested on macOS (Darwin 25.3.0, Apple Silicon)
- [x] `bash -n` syntax check passes on all modified files
- [x] `portable_flock` signal cleanup verified (lock dir removed on SIGINT)
- [x] `rotate_log` verified: 600-line file correctly trimmed to 500 lines
- [ ] Linux regression test (existing `flock`/`date -d` paths unchanged)

Fixes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a cross-platform compatibility layer with portable utilities for date/time calculations, ISO↔epoch conversions, SHA‑256 hashing, file locking (including non-blocking attempts), atomic append operations, and log rotation; added an idempotent guard and auto-sourcing by configuration.
* **Bug Fixes**
  * Improved date handling for macOS compatibility and corrected UTC handling in date construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->