### PR TITLE
feat(integrity): memory integrity verification at Reflector and Dream Cycle boundaries

### DIFF
--- a/config/integrity.yaml
+++ b/config/integrity.yaml
@@ -1,0 +1,42 @@
+# Memory Integrity Verification Configuration
+# See: https://github.com/gavdalf/total-recall/issues/18
+#
+# All settings have sensible defaults and can also be overridden via
+# environment variables (env vars take precedence).
+
+integrity:
+  # Set to false to disable all integrity checks without removing them from scripts.
+  enabled: true
+
+  # Number of observations to sample at each checkpoint.
+  # Increase for higher confidence; decrease to reduce API cost.
+  # Env: INTEGRITY_SAMPLE_N
+  sample_n: 10
+
+  # Block the pipeline (exit 2) when a flag is raised.
+  # Default: false — flag and log, but continue.
+  # Recommended: leave false until you have calibration data.
+  # Env: INTEGRITY_BLOCK_ON_FLAG
+  block_on_flag: false
+
+  thresholds:
+    # Global fallback threshold for cosine similarity.
+    # Values below this trigger a drift flag.
+    # Env: INTEGRITY_THRESHOLD
+    default: 0.85
+
+    # Per-checkpoint overrides (optional).
+    # Set independently once you have calibration data to tune each boundary.
+    # Env: INTEGRITY_REFLECTOR_THRESHOLD
+    reflector_threshold: 0.85
+
+    # Env: INTEGRITY_DREAM_THRESHOLD
+    dream_threshold: 0.85
+
+  # Embedding model (Gemini Embedding 2 — standalone, no Phase 7B dependency).
+  # When Phase 7B lands, refactor to reuse cached embeddings from that pipeline.
+  embedding_model: text-embedding-004
+
+  # API key environment variable name to use for embeddings.
+  # Falls back to GOOGLE_API_KEY if GEMINI_API_KEY is not set.
+  api_key_env: GEMINI_API_KEY

--- a/scripts/dream-cycle.sh
+++ b/scripts/dream-cycle.sh
@@ -108,6 +108,15 @@ cmd_preflight() {
     git_snapshot "Pre-dream snapshot: $(ISO_STAMP_UTC)"
   fi
 
+  # --- Integrity: capture pre-dream sample ---
+  local integrity_script="$SKILL_DIR/scripts/integrity-check.sh"
+  local integrity_pre_state="$MEMORY_DIR/.integrity-pre-dream.json"
+  if [ -f "$integrity_script" ] && [ "${INTEGRITY_ENABLED:-true}" = "true" ]; then
+    local dry_run_flag=""
+    [ "$dry_run" = "true" ] && dry_run_flag="--dry-run"
+    bash "$integrity_script" dream $dry_run_flag capture "$OBSERVATIONS_FILE" "$integrity_pre_state" >/dev/null 2>&1 || true
+  fi
+
   info "{\"status\":\"ok\",\"command\":\"preflight\",\"dry_run\":$dry_run,\"backup\":\"$backup_file\"}"
 }
 
@@ -285,6 +294,13 @@ cmd_update_observations() {
   after_tokens="$(token_count "$tmp")"
 
   mv "$tmp" "$OBSERVATIONS_FILE"
+
+  # --- Integrity: verify post-dream similarity ---
+  local integrity_script="$SKILL_DIR/scripts/integrity-check.sh"
+  local integrity_pre_state="$MEMORY_DIR/.integrity-pre-dream.json"
+  if [ -f "$integrity_script" ] && [ "${INTEGRITY_ENABLED:-true}" = "true" ] && [ -f "$integrity_pre_state" ]; then
+    bash "$integrity_script" dream "" verify "$OBSERVATIONS_FILE" "$integrity_pre_state" >/dev/null 2>&1 || true
+  fi
 
   git -C "$OPENCLAW_WORKSPACE" add "$OBSERVATIONS_FILE"
   git -C "$OPENCLAW_WORKSPACE" commit -m "Dream cycle: update observations $(ISO_STAMP_UTC)" || true

--- a/scripts/dream-cycle.sh
+++ b/scripts/dream-cycle.sh
@@ -299,7 +299,16 @@ cmd_update_observations() {
   local integrity_script="$SKILL_DIR/scripts/integrity-check.sh"
   local integrity_pre_state="$MEMORY_DIR/.integrity-pre-dream.json"
   if [ -f "$integrity_script" ] && [ "${INTEGRITY_ENABLED:-true}" = "true" ] && [ -f "$integrity_pre_state" ]; then
-    bash "$integrity_script" dream "" verify "$OBSERVATIONS_FILE" "$integrity_pre_state" >/dev/null 2>&1 || true
+    local integrity_exit=0
+    bash "$integrity_script" dream verify "$OBSERVATIONS_FILE" "$integrity_pre_state" >/dev/null 2>&1 || integrity_exit=$?
+    if [ "$integrity_exit" -ne 0 ]; then
+      if [ "$integrity_exit" -eq 2 ] && [ "${INTEGRITY_BLOCK_ON_FLAG:-false}" = "true" ]; then
+        err "Integrity flag raised and INTEGRITY_BLOCK_ON_FLAG=true — halting pipeline"
+        exit 2
+      else
+        log "Integrity: verify returned exit $integrity_exit (non-fatal)"
+      fi
+    fi
   fi
 
   git -C "$OPENCLAW_WORKSPACE" add "$OBSERVATIONS_FILE"

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -4,8 +4,8 @@
 # https://github.com/gavdalf/total-recall/issues/18
 #
 # Usage:
-#   integrity-check.sh reflector [--dry-run]
-#   integrity-check.sh dream     [--dry-run]
+#   integrity-check.sh <reflector|dream> [--dry-run] capture <obs_file> <state_file>
+#   integrity-check.sh <reflector|dream> [--dry-run] verify  <obs_file> <state_file>
 #
 # Samples observations before a compression boundary, embeds both pre- and
 # post-versions with Gemini Embedding 2, and flags any pair whose cosine
@@ -18,6 +18,7 @@
 # Exit codes:
 #   0  Check passed (or flag-only mode — flags written but no hard fail)
 #   1  Fatal error (missing files, API failure with no fallback)
+#   2  Integrity flag raised with INTEGRITY_BLOCK_ON_FLAG=true (blocking mode)
 #
 # Environment / config keys (all optional — see integrity.yaml):
 #   INTEGRITY_ENABLED              true|false (default: true)
@@ -37,13 +38,14 @@ WORKSPACE="${OPENCLAW_WORKSPACE:-$(cd "$SKILL_DIR/../.." && pwd)}"
 MEMORY_DIR="${MEMORY_DIR:-$WORKSPACE/memory}"
 LOGS_DIR="${LOGS_DIR:-$WORKSPACE/logs}"
 
+mkdir -p "$LOGS_DIR"
+
 INTEGRITY_LOG="$MEMORY_DIR/integrity-log.md"
 DREAM_LOG_DIR="$MEMORY_DIR/dream-logs"
 INTEGRITY_CFG="$SKILL_DIR/config/integrity.yaml"
 
 # Load env — safe line-by-line parser (no eval; values treated as data, not commands)
 if [ -f "$WORKSPACE/.env" ]; then
-  _ALLOWED_KEYS_RE='^(INTEGRITY_[A-Z_]+|GEMINI_API_KEY|GOOGLE_API_KEY|LLM_API_KEY)$'
   while IFS= read -r _line || [ -n "$_line" ]; do
     # Skip empty lines and comments
     case "$_line" in ''|'#'*) continue ;; esac
@@ -62,7 +64,7 @@ if [ -f "$WORKSPACE/.env" ]; then
     esac
     export "$_key=$_val"
   done < "$WORKSPACE/.env"
-  unset _line _key _val _ALLOWED_KEYS_RE
+  unset _line _key _val
 fi
 
 # Config defaults (can be overridden by integrity.yaml or env)

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -62,7 +62,8 @@ GEMINI_API_KEY="${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
 
 CHECKPOINT="${1:-}"  # "reflector" or "dream"
 DRY_RUN="false"
-[ "${2:-}" = "--dry-run" ] && DRY_RUN="true"
+# Consume optional --dry-run flag (may appear as $2 before or alongside subcommand)
+shift || true  # shift past CHECKPOINT
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -80,7 +81,9 @@ import yaml, sys
 try:
     with open('$INTEGRITY_CFG') as f:
         d = yaml.safe_load(f)
-    val = d.get('thresholds', {}).get('$key', $default)
+    # Read from nested integrity.thresholds, not document root
+    thresholds = (d or {}).get('integrity', {}).get('thresholds', {})
+    val = thresholds.get('$key', $default)
     print(val)
 except Exception:
     print($default)
@@ -327,6 +330,22 @@ cmd_verify() {
   local min_sim="1.0"
   local flag_rows=""
 
+  # Guard: if no post embeddings were obtained, skip similarity checks
+  if [ "${#post_vecs[@]}" -eq 0 ]; then
+    log "verify: no post-compression embeddings available (API unavailable or empty file) — skipping similarity checks"
+    rm -f "$state_in"
+    echo "{\"status\":\"skipped\",\"reason\":\"no_post_embeddings\",\"checkpoint\":\"$CHECKPOINT\"}"
+    exit 0
+  fi
+
+  # Guard: python3 is required for float arithmetic
+  if ! command -v python3 &>/dev/null; then
+    log "verify: python3 not available — skipping similarity checks"
+    rm -f "$state_in"
+    echo "{\"status\":\"skipped\",\"reason\":\"python3_unavailable\",\"checkpoint\":\"$CHECKPOINT\"}"
+    exit 0
+  fi
+
   while IFS= read -r pre_entry; do
     local pre_text
     pre_text=$(echo "$pre_entry" | jq -r '.text')
@@ -399,9 +418,19 @@ fi
 
 [ -n "$CHECKPOINT" ] || { err "Usage: integrity-check.sh <reflector|dream> [--dry-run] <capture|verify> [args...]"; exit 1; }
 
-COMMAND="${3:-}"
-ARG1="${4:-}"
-ARG2="${5:-}"
+# Parse remaining args: [--dry-run] <command> [arg1] [arg2]
+REMAINING_ARGS=()
+for _arg in "$@"; do
+  if [ "$_arg" = "--dry-run" ]; then
+    DRY_RUN="true"
+  else
+    REMAINING_ARGS+=("$_arg")
+  fi
+done
+
+COMMAND="${REMAINING_ARGS[0]:-}"
+ARG1="${REMAINING_ARGS[1]:-}"
+ARG2="${REMAINING_ARGS[2]:-}"
 
 case "$COMMAND" in
   capture) cmd_capture "$ARG1" "$ARG2" ;;

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+# Memory Integrity Verification — semantic drift detection
+# Implements the design approved in issue #18:
+# https://github.com/gavdalf/total-recall/issues/18
+#
+# Usage:
+#   integrity-check.sh reflector [--dry-run]
+#   integrity-check.sh dream     [--dry-run]
+#
+# Samples observations before a compression boundary, embeds both pre- and
+# post-versions with Gemini Embedding 2, and flags any pair whose cosine
+# similarity falls below the configured threshold.
+#
+# Flags are written to:
+#   - memory/integrity-log.md   (machine-parseable + human-readable)
+#   - The dream log entry       (inline, visible during normal review)
+#
+# Exit codes:
+#   0  Check passed (or flag-only mode — flags written but no hard fail)
+#   1  Fatal error (missing files, API failure with no fallback)
+#
+# Environment / config keys (all optional — see integrity.yaml):
+#   INTEGRITY_ENABLED              true|false (default: true)
+#   INTEGRITY_SAMPLE_N             observations to sample (default: 10)
+#   INTEGRITY_THRESHOLD            global cosine floor (default: 0.85)
+#   INTEGRITY_REFLECTOR_THRESHOLD  per-type override for reflector boundary
+#   INTEGRITY_DREAM_THRESHOLD      per-type override for dream boundary
+#   INTEGRITY_BLOCK_ON_FLAG        true|false — block pipeline on flag (default: false)
+#   GEMINI_API_KEY                 required; also accepts GOOGLE_API_KEY
+
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SKILL_DIR/scripts/_compat.sh"
+
+WORKSPACE="${OPENCLAW_WORKSPACE:-$(cd "$SKILL_DIR/../.." && pwd)}"
+MEMORY_DIR="${MEMORY_DIR:-$WORKSPACE/memory}"
+LOGS_DIR="${LOGS_DIR:-$WORKSPACE/logs}"
+
+INTEGRITY_LOG="$MEMORY_DIR/integrity-log.md"
+DREAM_LOG_DIR="$MEMORY_DIR/dream-logs"
+INTEGRITY_CFG="$SKILL_DIR/config/integrity.yaml"
+
+# Load env
+if [ -f "$WORKSPACE/.env" ]; then
+  set -a
+  eval "$(grep -E '^(INTEGRITY_|GEMINI_API_KEY|GOOGLE_API_KEY|LLM_API_KEY)' "$WORKSPACE/.env" 2>/dev/null)" || true
+  set +a
+fi
+
+# Config defaults (can be overridden by integrity.yaml or env)
+INTEGRITY_ENABLED="${INTEGRITY_ENABLED:-true}"
+SAMPLE_N="${INTEGRITY_SAMPLE_N:-10}"
+GLOBAL_THRESHOLD="${INTEGRITY_THRESHOLD:-0.85}"
+REFLECTOR_THRESHOLD="${INTEGRITY_REFLECTOR_THRESHOLD:-$GLOBAL_THRESHOLD}"
+DREAM_THRESHOLD="${INTEGRITY_DREAM_THRESHOLD:-$GLOBAL_THRESHOLD}"
+BLOCK_ON_FLAG="${INTEGRITY_BLOCK_ON_FLAG:-false}"
+
+# Gemini Embedding 2 endpoint
+GEMINI_EMBED_MODEL="text-embedding-004"
+GEMINI_API_KEY="${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
+
+CHECKPOINT="${1:-}"  # "reflector" or "dream"
+DRY_RUN="false"
+[ "${2:-}" = "--dry-run" ] && DRY_RUN="true"
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [integrity] $*" >> "$LOGS_DIR/integrity.log" 2>/dev/null || true; }
+info() { echo "$*"; }
+err()  { echo "ERROR [integrity]: $*" >&2; }
+
+# Load per-type thresholds from integrity.yaml if present
+_load_yaml_threshold() {
+  local key="$1"
+  local default="$2"
+  if [ -f "$INTEGRITY_CFG" ] && command -v python3 &>/dev/null; then
+    python3 -c "
+import yaml, sys
+try:
+    with open('$INTEGRITY_CFG') as f:
+        d = yaml.safe_load(f)
+    val = d.get('thresholds', {}).get('$key', $default)
+    print(val)
+except Exception:
+    print($default)
+" 2>/dev/null || echo "$default"
+  else
+    echo "$default"
+  fi
+}
+
+# Embed a text string using Gemini Embedding 2. Returns JSON with .embedding array.
+_embed() {
+  local text="$1"
+  local task_type="${2:-SEMANTIC_SIMILARITY}"
+
+  if [ -z "$GEMINI_API_KEY" ]; then
+    err "GEMINI_API_KEY not set — cannot embed"
+    return 1
+  fi
+
+  local payload
+  payload=$(jq -n \
+    --arg text "$text" \
+    --arg task "$task_type" \
+    '{"model": "models/text-embedding-004", "content": {"parts": [{"text": $text}]}, "taskType": $task}')
+
+  local response
+  response=$(curl -s --max-time 30 \
+    "https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_EMBED_MODEL}:embedContent?key=${GEMINI_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "$payload" 2>/dev/null) || { err "Embedding API call failed"; return 1; }
+
+  # Check for error in response
+  local api_err
+  api_err=$(echo "$response" | jq -r '.error.message // empty' 2>/dev/null)
+  if [ -n "$api_err" ]; then
+    err "Embedding API error: $api_err"
+    return 1
+  fi
+
+  echo "$response" | jq -c '.embedding.values // empty'
+}
+
+# Cosine similarity between two JSON float arrays (Python required for float math)
+_cosine_sim() {
+  local vec_a="$1"
+  local vec_b="$2"
+  python3 - <<PYEOF
+import json, math
+a = json.loads("""$vec_a""")
+b = json.loads("""$vec_b""")
+dot = sum(x*y for x,y in zip(a,b))
+mag_a = math.sqrt(sum(x*x for x in a))
+mag_b = math.sqrt(sum(y*y for y in b))
+denom = mag_a * mag_b
+print(round(dot / denom, 4) if denom > 0 else 0.0)
+PYEOF
+}
+
+# Randomly sample N lines from a file (one observation per line kept as-is)
+_sample_observations() {
+  local obs_file="$1"
+  local n="$2"
+  # Treat each non-empty line as one "observation unit"
+  grep -v '^[[:space:]]*$' "$obs_file" | shuf -n "$n" 2>/dev/null || grep -v '^[[:space:]]*$' "$obs_file" | head -n "$n"
+}
+
+# Append an integrity result entry to integrity-log.md
+_write_integrity_log() {
+  local ts="$1"
+  local checkpoint="$2"
+  local samples_checked="$3"
+  local flagged="$4"
+  local min_sim="$5"
+  local flag_table="$6"
+
+  mkdir -p "$MEMORY_DIR"
+
+  # Machine-parseable header line (invisible in rendered markdown)
+  local status="PASSED"
+  [ "$flagged" -gt 0 ] && status="FLAG"
+
+  {
+    echo ""
+    echo "<!-- integrity:${checkpoint} ts=${ts} samples=${samples_checked} flagged=${flagged} min_sim=${min_sim} status=${status} -->"
+    echo ""
+    echo "## ${checkpoint^} Integrity Check — ${ts}"
+    echo ""
+    if [ "$flagged" -eq 0 ]; then
+      echo "**Integrity check:** PASSED (${samples_checked} samples, lowest similarity: ${min_sim})"
+    else
+      echo "**Integrity check:** FLAG (${flagged}/${samples_checked} samples below threshold)"
+      echo ""
+      echo "$flag_table"
+    fi
+    echo ""
+    echo "---"
+  } >> "$INTEGRITY_LOG"
+}
+
+# Append a short summary to today's dream log
+_write_dream_log_entry() {
+  local ts="$1"
+  local checkpoint="$2"
+  local samples_checked="$3"
+  local flagged="$4"
+  local min_sim="$5"
+
+  local today
+  today=$(date -u '+%Y-%m-%d')
+  local dream_log="$DREAM_LOG_DIR/dream-${today}.md"
+  mkdir -p "$DREAM_LOG_DIR"
+
+  if [ "$flagged" -eq 0 ]; then
+    echo "<!-- integrity:${checkpoint} ts=${ts} samples=${samples_checked} min_sim=${min_sim} status=PASSED -->" >> "$dream_log"
+    echo "_Integrity check (${checkpoint}): PASSED — ${samples_checked} samples, min similarity ${min_sim}_" >> "$dream_log"
+  else
+    echo "<!-- integrity:${checkpoint} ts=${ts} samples=${samples_checked} flagged=${flagged} min_sim=${min_sim} status=FLAG -->" >> "$dream_log"
+    echo "⚠️ _Integrity check (${checkpoint}): FLAG — ${flagged}/${samples_checked} samples below threshold. Review \`memory/integrity-log.md\` for details._" >> "$dream_log"
+  fi
+  echo "" >> "$dream_log"
+}
+
+# ─── Phase: Capture pre-compression sample ───────────────────────────────────
+
+cmd_capture() {
+  # Called BEFORE the compression step (reflector or dream-cycle preflight).
+  # Writes sampled observations + their embeddings to a temp state file.
+  local obs_file="${1:-$MEMORY_DIR/observations.md}"
+  local state_out="${2:-$MEMORY_DIR/.integrity-pre-${CHECKPOINT}.json}"
+
+  [ -f "$obs_file" ] || { err "Observations file not found: $obs_file"; exit 1; }
+
+  local threshold
+  threshold=$(_load_yaml_threshold "${CHECKPOINT}_threshold" "${GLOBAL_THRESHOLD}")
+
+  log "capture: sampling $SAMPLE_N observations from $obs_file (checkpoint=$CHECKPOINT)"
+
+  local samples=()
+  while IFS= read -r line; do
+    samples+=("$line")
+  done < <(_sample_observations "$obs_file" "$SAMPLE_N")
+
+  if [ "${#samples[@]}" -eq 0 ]; then
+    log "capture: no observations to sample, skipping"
+    echo '{"status":"skipped","reason":"empty"}' > "$state_out"
+    exit 0
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log "capture: dry-run mode — would embed ${#samples[@]} observations"
+    echo "{\"status\":\"dry-run\",\"count\":${#samples[@]}}"
+    exit 0
+  fi
+
+  # Build JSON array of {text, embedding} pairs
+  local entries='[]'
+  local i=0
+  for sample in "${samples[@]}"; do
+    local vec
+    vec=$(_embed "$sample") || { log "capture: embed failed for sample $i, skipping"; ((i++)); continue; }
+    if [ -n "$vec" ]; then
+      entries=$(echo "$entries" | jq --argjson v "$vec" --arg t "$sample" '. + [{"text": $t, "embedding": $v}]')
+    fi
+    ((i++)) || true
+  done
+
+  local captured_count
+  captured_count=$(echo "$entries" | jq 'length')
+  log "capture: $captured_count samples embedded, writing state to $state_out"
+
+  jq -n \
+    --argjson entries "$entries" \
+    --arg ts "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg checkpoint "$CHECKPOINT" \
+    --argjson threshold "$threshold" \
+    '{"captured_at": $ts, "checkpoint": $checkpoint, "threshold": $threshold, "samples": $entries}' \
+    > "$state_out"
+
+  echo "{\"status\":\"ok\",\"captured\":$captured_count}"
+}
+
+# ─── Phase: Verify post-compression similarity ───────────────────────────────
+
+cmd_verify() {
+  # Called AFTER compression. Re-embeds a post-compression snapshot
+  # and compares each pre-capture embedding against the nearest match
+  # in the current observations file.
+  local obs_file="${1:-$MEMORY_DIR/observations.md}"
+  local state_in="${2:-$MEMORY_DIR/.integrity-pre-${CHECKPOINT}.json}"
+
+  [ -f "$obs_file" ] || { err "Post-compression observations file not found: $obs_file"; exit 1; }
+
+  if [ ! -f "$state_in" ]; then
+    log "verify: no pre-capture state found at $state_in — nothing to verify"
+    exit 0
+  fi
+
+  local state
+  state=$(cat "$state_in")
+
+  local status
+  status=$(echo "$state" | jq -r '.status // empty')
+  if [ "$status" = "skipped" ] || [ "$status" = "dry-run" ]; then
+    log "verify: pre-capture was $status — skipping verify"
+    rm -f "$state_in"
+    exit 0
+  fi
+
+  local threshold
+  threshold=$(echo "$state" | jq -r '.threshold')
+  local pre_samples
+  pre_samples=$(echo "$state" | jq -c '.samples[]')
+
+  if [ -z "$pre_samples" ]; then
+    log "verify: no pre-capture samples found, skipping"
+    rm -f "$state_in"
+    exit 0
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log "verify: dry-run mode — would verify against $obs_file"
+    rm -f "$state_in"
+    exit 0
+  fi
+
+  # Embed a representative sample of post-compression observations
+  local post_samples=()
+  while IFS= read -r line; do
+    post_samples+=("$line")
+  done < <(_sample_observations "$obs_file" "$((SAMPLE_N * 2))")
+
+  # Build post-embeddings
+  local post_vecs=()
+  for ps in "${post_samples[@]}"; do
+    local vec
+    vec=$(_embed "$ps") || continue
+    [ -n "$vec" ] && post_vecs+=("$vec")
+  done
+
+  local ts
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  local samples_checked=0
+  local flagged=0
+  local min_sim="1.0"
+  local flag_rows=""
+
+  while IFS= read -r pre_entry; do
+    local pre_text
+    pre_text=$(echo "$pre_entry" | jq -r '.text')
+    local pre_vec
+    pre_vec=$(echo "$pre_entry" | jq -c '.embedding')
+
+    # Find the best-matching post embedding (maximum cosine similarity)
+    local best_sim="0.0"
+    for post_vec in "${post_vecs[@]}"; do
+      local sim
+      sim=$(_cosine_sim "$pre_vec" "$post_vec") || continue
+      # Keep max
+      best_sim=$(python3 -c "print(max($best_sim, $sim))")
+    done
+
+    ((samples_checked++)) || true
+
+    # Update running minimum
+    min_sim=$(python3 -c "print(min($min_sim, $best_sim))")
+
+    # Check threshold
+    local below
+    below=$(python3 -c "print(1 if $best_sim < $threshold else 0)")
+    if [ "$below" = "1" ]; then
+      ((flagged++)) || true
+      local short_text
+      short_text=$(echo "$pre_text" | cut -c1-50 | tr '\n' ' ')
+      flag_rows="${flag_rows}| \`${short_text}...\` | ${best_sim} | ⚠️ FLAGGED |\n"
+      log "flag: '${short_text}' sim=$best_sim < threshold=$threshold"
+    fi
+  done < <(echo "$state" | jq -c '.samples[]')
+
+  # Build flag table if needed
+  local flag_table=""
+  if [ "$flagged" -gt 0 ]; then
+    flag_table="| Observation (first 50 chars) | Pre-compress sim | Status |\n|------------------------------|-----------------|--------|\n${flag_rows}"
+  fi
+
+  # Write outputs
+  _write_integrity_log "$ts" "$CHECKPOINT" "$samples_checked" "$flagged" "$min_sim" "$flag_table"
+  _write_dream_log_entry "$ts" "$CHECKPOINT" "$samples_checked" "$flagged" "$min_sim"
+
+  log "verify: done — $samples_checked checked, $flagged flagged, min_sim=$min_sim"
+
+  # Clean up state file
+  rm -f "$state_in"
+
+  # Emit structured result
+  local status_word="PASSED"
+  [ "$flagged" -gt 0 ] && status_word="FLAG"
+
+  echo "{\"status\":\"$status_word\",\"checkpoint\":\"$CHECKPOINT\",\"samples_checked\":$samples_checked,\"flagged\":$flagged,\"min_sim\":$min_sim}"
+
+  # Block pipeline only if configured AND flag was raised
+  if [ "$flagged" -gt 0 ] && [ "$BLOCK_ON_FLAG" = "true" ]; then
+    err "Integrity flag raised and INTEGRITY_BLOCK_ON_FLAG=true — halting pipeline"
+    exit 2
+  fi
+
+  exit 0
+}
+
+# ─── Dispatch ─────────────────────────────────────────────────────────────────
+
+if [ "$INTEGRITY_ENABLED" != "true" ]; then
+  log "disabled — skipping"
+  echo '{"status":"disabled"}'
+  exit 0
+fi
+
+[ -n "$CHECKPOINT" ] || { err "Usage: integrity-check.sh <reflector|dream> [--dry-run] <capture|verify> [args...]"; exit 1; }
+
+COMMAND="${3:-}"
+ARG1="${4:-}"
+ARG2="${5:-}"
+
+case "$COMMAND" in
+  capture) cmd_capture "$ARG1" "$ARG2" ;;
+  verify)  cmd_verify  "$ARG1" "$ARG2" ;;
+  *)
+    err "Unknown command '$COMMAND'. Use: capture | verify"
+    exit 1
+    ;;
+esac

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -409,23 +409,22 @@ cmd_verify() {
     pre_vec=$(echo "$pre_entry" | jq -c '.embedding')
 
     # Find the best-matching post embedding (maximum cosine similarity)
+    # Use awk for float comparisons to avoid O(n²) python3 subprocess overhead.
     local best_sim="0.0"
     for post_vec in "${post_vecs[@]}"; do
       local sim
       sim=$(_cosine_sim "$pre_vec" "$post_vec") || continue
-      # Keep max
-      best_sim=$(python3 -c "print(max($best_sim, $sim))")
+      # Keep max — awk avoids a python3 subprocess per iteration
+      best_sim=$(awk "BEGIN{print ($sim > $best_sim) ? $sim : $best_sim}")
     done
 
     ((samples_checked++)) || true
 
-    # Update running minimum
-    min_sim=$(python3 -c "print(min($min_sim, $best_sim))")
+    # Update running minimum (awk, not python3 — no subprocess per sample)
+    min_sim=$(awk "BEGIN{print ($best_sim < $min_sim) ? $best_sim : $min_sim}")
 
-    # Check threshold
-    local below
-    below=$(python3 -c "print(1 if $best_sim < $threshold else 0)")
-    if [ "$below" = "1" ]; then
+    # Check threshold (awk inline float comparison, no subprocess)
+    if awk "BEGIN{exit ($best_sim < $threshold) ? 0 : 1}"; then
       ((flagged++)) || true
       local artifact_id
       artifact_id="obs-$(echo "$pre_text" | md5sum | cut -c1-8)"

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -41,11 +41,28 @@ INTEGRITY_LOG="$MEMORY_DIR/integrity-log.md"
 DREAM_LOG_DIR="$MEMORY_DIR/dream-logs"
 INTEGRITY_CFG="$SKILL_DIR/config/integrity.yaml"
 
-# Load env
+# Load env — safe line-by-line parser (no eval; values treated as data, not commands)
 if [ -f "$WORKSPACE/.env" ]; then
-  set -a
-  eval "$(grep -E '^(INTEGRITY_|GEMINI_API_KEY|GOOGLE_API_KEY|LLM_API_KEY)' "$WORKSPACE/.env" 2>/dev/null)" || true
-  set +a
+  _ALLOWED_KEYS_RE='^(INTEGRITY_[A-Z_]+|GEMINI_API_KEY|GOOGLE_API_KEY|LLM_API_KEY)$'
+  while IFS= read -r _line || [ -n "$_line" ]; do
+    # Skip empty lines and comments
+    case "$_line" in ''|'#'*) continue ;; esac
+    # Split on first '=' only
+    _key="${_line%%=*}"
+    _val="${_line#*=}"
+    # Validate key against allowlist
+    case "$_key" in
+      INTEGRITY_*|GEMINI_API_KEY|GOOGLE_API_KEY|LLM_API_KEY) ;;
+      *) continue ;;
+    esac
+    # Strip surrounding single or double quotes from value
+    case "$_val" in
+      \"*\") _val="${_val#\"}"; _val="${_val%\"}" ;;
+      \'*\') _val="${_val#\'}"; _val="${_val%\'}" ;;
+    esac
+    export "$_key=$_val"
+  done < "$WORKSPACE/.env"
+  unset _line _key _val _ALLOWED_KEYS_RE
 fi
 
 # Config defaults (can be overridden by integrity.yaml or env)
@@ -301,6 +318,7 @@ cmd_verify() {
 
   if [ ! -f "$state_in" ]; then
     log "verify: no pre-capture state found at $state_in — nothing to verify"
+    echo "{\"status\":\"skipped\",\"reason\":\"missing_pre_state\",\"checkpoint\":\"$CHECKPOINT\"}"
     exit 0
   fi
 
@@ -312,6 +330,7 @@ cmd_verify() {
   if [ "$status" = "skipped" ] || [ "$status" = "dry-run" ]; then
     log "verify: pre-capture was $status — skipping verify"
     rm -f "$state_in"
+    echo "{\"status\":\"skipped\",\"reason\":\"pre_capture_${status}\",\"checkpoint\":\"$CHECKPOINT\"}"
     exit 0
   fi
 
@@ -323,12 +342,14 @@ cmd_verify() {
   if [ -z "$pre_samples" ]; then
     log "verify: no pre-capture samples found, skipping"
     rm -f "$state_in"
+    echo "{\"status\":\"skipped\",\"reason\":\"empty_pre_state\",\"checkpoint\":\"$CHECKPOINT\"}"
     exit 0
   fi
 
   if [ "$DRY_RUN" = "true" ]; then
     log "verify: dry-run mode — would verify against $obs_file"
     rm -f "$state_in"
+    echo "{\"status\":\"skipped\",\"reason\":\"dry_run\",\"checkpoint\":\"$CHECKPOINT\"}"
     exit 0
   fi
 
@@ -394,10 +415,10 @@ cmd_verify() {
     below=$(python3 -c "print(1 if $best_sim < $threshold else 0)")
     if [ "$below" = "1" ]; then
       ((flagged++)) || true
-      local short_text
-      short_text=$(echo "$pre_text" | cut -c1-50 | tr '\n' ' ')
-      flag_rows="${flag_rows}| \`${short_text}...\` | ${best_sim} | ⚠️ FLAGGED |\n"
-      log "flag: '${short_text}' sim=$best_sim < threshold=$threshold"
+      local artifact_id
+      artifact_id="obs-$(echo "$pre_text" | md5sum | cut -c1-8)"
+      flag_rows="${flag_rows}| \`[redacted:${artifact_id}]\` | ${best_sim} | ⚠️ FLAGGED |\n"
+      log "flag: artifact=$artifact_id sim=$best_sim < threshold=$threshold"
     fi
   done < <(echo "$state" | jq -c '.samples[]')
 

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -147,19 +147,22 @@ _embed() {
 }
 
 # Cosine similarity between two JSON float arrays (Python required for float math)
+# Vectors are passed via stdin as a JSON object {"a": [...], "b": [...]} to avoid
+# heredoc quoting fragility with triple-quote embedding.
 _cosine_sim() {
   local vec_a="$1"
   local vec_b="$2"
-  python3 - <<PYEOF
-import json, math
-a = json.loads("""$vec_a""")
-b = json.loads("""$vec_b""")
+  jq -n --argjson a "$vec_a" --argjson b "$vec_b" '{"a":$a,"b":$b}' | \
+  python3 -c "
+import json, math, sys
+data = json.load(sys.stdin)
+a, b = data['a'], data['b']
 dot = sum(x*y for x,y in zip(a,b))
 mag_a = math.sqrt(sum(x*x for x in a))
 mag_b = math.sqrt(sum(y*y for y in b))
 denom = mag_a * mag_b
 print(round(dot / denom, 4) if denom > 0 else 0.0)
-PYEOF
+"
 }
 
 # Randomly sample N lines from a file (one observation per line kept as-is)
@@ -167,7 +170,14 @@ _sample_observations() {
   local obs_file="$1"
   local n="$2"
   # Treat each non-empty line as one "observation unit"
-  grep -v '^[[:space:]]*$' "$obs_file" | shuf -n "$n" 2>/dev/null || grep -v '^[[:space:]]*$' "$obs_file" | head -n "$n"
+  # shuf is GNU coreutils (unavailable on macOS by default); fall back to head -n
+  # with a warning so callers know sampling is deterministic in that case.
+  if command -v shuf &>/dev/null; then
+    grep -v '^[[:space:]]*$' "$obs_file" | shuf -n "$n"
+  else
+    log "WARN: shuf not available — falling back to deterministic first-$n sampling (install coreutils for random sampling)"
+    grep -v '^[[:space:]]*$' "$obs_file" | head -n "$n"
+  fi
 }
 
 # Append an integrity result entry to integrity-log.md

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -217,7 +217,15 @@ cmd_capture() {
   [ -f "$obs_file" ] || { err "Observations file not found: $obs_file"; exit 1; }
 
   local threshold
-  threshold=$(_load_yaml_threshold "${CHECKPOINT}_threshold" "${GLOBAL_THRESHOLD}")
+  # Resolve env-var fallback per checkpoint so INTEGRITY_REFLECTOR_THRESHOLD /
+  # INTEGRITY_DREAM_THRESHOLD are honoured when no YAML config is present.
+  local _env_threshold
+  case "$CHECKPOINT" in
+    reflector) _env_threshold="$REFLECTOR_THRESHOLD" ;;
+    dream)     _env_threshold="$DREAM_THRESHOLD"     ;;
+    *)         _env_threshold="$GLOBAL_THRESHOLD"    ;;
+  esac
+  threshold=$(_load_yaml_threshold "${CHECKPOINT}_threshold" "$_env_threshold")
 
   log "capture: sampling $SAMPLE_N observations from $obs_file (checkpoint=$CHECKPOINT)"
 

--- a/scripts/integrity-check.sh
+++ b/scripts/integrity-check.sh
@@ -57,7 +57,7 @@ DREAM_THRESHOLD="${INTEGRITY_DREAM_THRESHOLD:-$GLOBAL_THRESHOLD}"
 BLOCK_ON_FLAG="${INTEGRITY_BLOCK_ON_FLAG:-false}"
 
 # Gemini Embedding 2 endpoint
-GEMINI_EMBED_MODEL="text-embedding-004"
+GEMINI_EMBED_MODEL="gemini-embedding-2-preview"
 GEMINI_API_KEY="${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
 
 CHECKPOINT="${1:-}"  # "reflector" or "dream"
@@ -107,7 +107,8 @@ _embed() {
   payload=$(jq -n \
     --arg text "$text" \
     --arg task "$task_type" \
-    '{"model": "models/text-embedding-004", "content": {"parts": [{"text": $text}]}, "taskType": $task}')
+    --arg model "models/${GEMINI_EMBED_MODEL}" \
+    '{"model": $model, "content": {"parts": [{"text": $text}]}, "taskType": $task}')
 
   local response
   response=$(curl -s --max-time 30 \
@@ -176,7 +177,7 @@ _write_integrity_log() {
     else
       echo "**Integrity check:** FLAG (${flagged}/${samples_checked} samples below threshold)"
       echo ""
-      echo "$flag_table"
+      printf "%b\n" "$flag_table"
     fi
     echo ""
     echo "---"
@@ -246,6 +247,14 @@ cmd_capture() {
     exit 0
   fi
 
+  # Without an API key no embeddings can be obtained — mark skipped immediately
+  if [ -z "$GEMINI_API_KEY" ]; then
+    log "capture: GEMINI_API_KEY not set — skipping embedding"
+    echo '{"status":"skipped","reason":"no_api_key"}' > "$state_out"
+    echo '{"status":"skipped","captured":0}'
+    exit 0
+  fi
+
   # Build JSON array of {text, embedding} pairs
   local entries='[]'
   local i=0
@@ -270,7 +279,13 @@ cmd_capture() {
     '{"captured_at": $ts, "checkpoint": $checkpoint, "threshold": $threshold, "samples": $entries}' \
     > "$state_out"
 
-  echo "{\"status\":\"ok\",\"captured\":$captured_count}"
+  if [ "$captured_count" -eq 0 ]; then
+    log "capture: 0 embeddings obtained — marking state as skipped"
+    echo '{"status":"skipped","reason":"captured_zero"}' > "$state_out"
+    echo "{\"status\":\"skipped\",\"captured\":0}"
+  else
+    echo "{\"status\":\"ok\",\"captured\":$captured_count}"
+  fi
 }
 
 # ─── Phase: Verify post-compression similarity ───────────────────────────────
@@ -425,6 +440,13 @@ if [ "$INTEGRITY_ENABLED" != "true" ]; then
 fi
 
 [ -n "$CHECKPOINT" ] || { err "Usage: integrity-check.sh <reflector|dream> [--dry-run] <capture|verify> [args...]"; exit 1; }
+
+# Validate CHECKPOINT against exact known values to prevent downstream filenames
+# (.integrity-pre-$CHECKPOINT.json) from being created with bogus values
+case "$CHECKPOINT" in
+  reflector|dream) ;;
+  *) err "Unknown checkpoint: $CHECKPOINT (expected 'reflector' or 'dream')"; exit 1 ;;
+esac
 
 # Parse remaining args: [--dry-run] <command> [arg1] [arg2]
 REMAINING_ARGS=()

--- a/scripts/reflector-agent.sh
+++ b/scripts/reflector-agent.sh
@@ -99,7 +99,7 @@ INTEGRITY_SCRIPT="$SKILL_DIR/scripts/integrity-check.sh"
 INTEGRITY_PRE_STATE="$MEMORY_DIR/.integrity-pre-reflector.json"
 if [ -f "$INTEGRITY_SCRIPT" ] && [ "${INTEGRITY_ENABLED:-true}" = "true" ]; then
   log "Integrity: capturing pre-reflection sample"
-  bash "$INTEGRITY_SCRIPT" reflector "" capture "$OBSERVATIONS_FILE" "$INTEGRITY_PRE_STATE" 2>/dev/null || \
+  bash "$INTEGRITY_SCRIPT" reflector capture "$OBSERVATIONS_FILE" "$INTEGRITY_PRE_STATE" 2>/dev/null || \
     log "Integrity: capture failed (non-fatal — check will be skipped)"
 fi
 
@@ -186,9 +186,15 @@ log "Reflection complete. $OBS_WORDS → $NEW_WORDS words ($REDUCTION% reduction
 # --- Integrity: verify post-reflection similarity ---
 if [ -f "$INTEGRITY_SCRIPT" ] && [ "${INTEGRITY_ENABLED:-true}" = "true" ] && [ -f "$INTEGRITY_PRE_STATE" ]; then
   log "Integrity: verifying post-reflection similarity"
-  INTEGRITY_RESULT=$(bash "$INTEGRITY_SCRIPT" reflector "" verify "$OBSERVATIONS_FILE" "$INTEGRITY_PRE_STATE" 2>/dev/null) || \
-    log "Integrity: verify failed (non-fatal)"
+  INTEGRITY_EXIT=0
+  INTEGRITY_RESULT=$(bash "$INTEGRITY_SCRIPT" reflector verify "$OBSERVATIONS_FILE" "$INTEGRITY_PRE_STATE" 2>&1) || INTEGRITY_EXIT=$?
   [ -n "$INTEGRITY_RESULT" ] && log "Integrity result: $INTEGRITY_RESULT"
+  if [ "$INTEGRITY_EXIT" -eq 2 ] && [ "${INTEGRITY_BLOCK_ON_FLAG:-false}" = "true" ]; then
+    log "Integrity: flag raised and INTEGRITY_BLOCK_ON_FLAG=true — halting pipeline"
+    exit 2
+  elif [ "$INTEGRITY_EXIT" -ne 0 ] && [ "$INTEGRITY_EXIT" -ne 2 ]; then
+    log "Integrity: verify returned exit $INTEGRITY_EXIT (non-fatal)"
+  fi
 fi
 
 # Clean old backups (keep last 10) — null-safe

--- a/scripts/reflector-agent.sh
+++ b/scripts/reflector-agent.sh
@@ -94,6 +94,15 @@ BACKUP_FILE="$BACKUP_DIR/observations-$(date '+%Y%m%d-%H%M%S').md"
 cp "$OBSERVATIONS_FILE" "$BACKUP_FILE"
 log "Backed up to $BACKUP_FILE"
 
+# --- Integrity: capture pre-reflection sample ---
+INTEGRITY_SCRIPT="$SKILL_DIR/scripts/integrity-check.sh"
+INTEGRITY_PRE_STATE="$MEMORY_DIR/.integrity-pre-reflector.json"
+if [ -f "$INTEGRITY_SCRIPT" ] && [ "${INTEGRITY_ENABLED:-true}" = "true" ]; then
+  log "Integrity: capturing pre-reflection sample"
+  bash "$INTEGRITY_SCRIPT" reflector "" capture "$OBSERVATIONS_FILE" "$INTEGRITY_PRE_STATE" 2>/dev/null || \
+    log "Integrity: capture failed (non-fatal — check will be skipped)"
+fi
+
 CURRENT_OBS=$(cat "$OBSERVATIONS_FILE")
 SYSTEM_PROMPT=$(cat "$REFLECTOR_PROMPT")
 TODAY=$(date '+%Y-%m-%d')
@@ -173,6 +182,14 @@ mv "$TMPOUT" "$OBSERVATIONS_FILE"
 NEW_WORDS=$(wc -w < "$OBSERVATIONS_FILE")
 REDUCTION=$(( (OBS_WORDS - NEW_WORDS) * 100 / OBS_WORDS ))
 log "Reflection complete. $OBS_WORDS → $NEW_WORDS words ($REDUCTION% reduction)"
+
+# --- Integrity: verify post-reflection similarity ---
+if [ -f "$INTEGRITY_SCRIPT" ] && [ "${INTEGRITY_ENABLED:-true}" = "true" ] && [ -f "$INTEGRITY_PRE_STATE" ]; then
+  log "Integrity: verifying post-reflection similarity"
+  INTEGRITY_RESULT=$(bash "$INTEGRITY_SCRIPT" reflector "" verify "$OBSERVATIONS_FILE" "$INTEGRITY_PRE_STATE" 2>/dev/null) || \
+    log "Integrity: verify failed (non-fatal)"
+  [ -n "$INTEGRITY_RESULT" ] && log "Integrity result: $INTEGRITY_RESULT"
+fi
 
 # Clean old backups (keep last 10) — null-safe
 find "$BACKUP_DIR" -name "observations-*.md" -type f | sort -r | tail -n +11 | while IFS= read -r old; do

--- a/tests/validate-fixes.sh
+++ b/tests/validate-fixes.sh
@@ -241,7 +241,7 @@ STUB
     echo "  ❌ 17a: capture argv shape wrong (expected 'reflector capture ...')"
     ok=0
   fi
-  > "$stub_log"
+  : > "$stub_log"
 
   # ── Test 17b: verify exit 2 propagates through dream-cycle wrapper ────────
   # Create a minimal dream-cycle wrapper that calls our stub
@@ -277,7 +277,7 @@ WRAPPER
     echo "  ❌ 17b: dream-cycle wrapper masked exit 2 (got exit $wrapper_exit)"
     ok=0
   fi
-  > "$stub_log"
+  : > "$stub_log"
 
   # ── Test 17c: --dry-run flag parsed correctly ─────────────────────────────
   STUB_LOG="$stub_log" INTEGRITY_ENABLED="true" \

--- a/tests/validate-fixes.sh
+++ b/tests/validate-fixes.sh
@@ -198,6 +198,107 @@ else
     ((FAILURES++))
 fi
 
+echo ""
+echo "📋 Test 17: execution-level — integrity-check.sh capture/verify argv + exit-code propagation"
+_run_integration_stub_test() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  # Create a minimal stubbed observations file
+  printf 'obs line one\nobs line two\nobs line three\n' > "$tmpdir/observations.md"
+
+  # Create a stubbed integrity-check.sh that inspects argv and exits with a known code
+  cat > "$tmpdir/integrity-check.sh" <<'STUB'
+#!/usr/bin/env bash
+CHECKPOINT="$1"; shift
+COMMAND=""
+DRY_RUN="false"
+for _a in "$@"; do
+  [ "$_a" = "--dry-run" ] && DRY_RUN="true" && continue
+  [ -z "$COMMAND" ] && COMMAND="$_a" && continue
+done
+# Record invocation for test inspection
+echo "$CHECKPOINT $COMMAND dry=$DRY_RUN" >> "${STUB_LOG:-/dev/null}"
+# cmd_capture: always succeeds
+# cmd_verify: exit 2 if BLOCK requested to test propagation
+if [ "$COMMAND" = "verify" ] && [ "${STUB_BLOCK:-false}" = "true" ]; then
+  exit 2
+fi
+exit 0
+STUB
+  chmod +x "$tmpdir/integrity-check.sh"
+
+  local stub_log="$tmpdir/stub.log"
+  local ok=1
+
+  # ── Test 17a: capture is called with correct CHECKPOINT arg ──────────────
+  STUB_LOG="$stub_log" INTEGRITY_ENABLED="true" \
+    bash "$tmpdir/integrity-check.sh" reflector capture "$tmpdir/observations.md" "$tmpdir/pre.json" 2>/dev/null
+  if grep -q "^reflector capture" "$stub_log" 2>/dev/null; then
+    echo "  ✅ 17a: capture called with CHECKPOINT=reflector"
+  else
+    echo "  ❌ 17a: capture argv shape wrong (expected 'reflector capture ...')"
+    ok=0
+  fi
+  > "$stub_log"
+
+  # ── Test 17b: verify exit 2 propagates through dream-cycle wrapper ────────
+  # Create a minimal dream-cycle wrapper that calls our stub
+  cat > "$tmpdir/dream-cycle-wrapper.sh" <<WRAPPER
+#!/usr/bin/env bash
+SKILL_DIR="$tmpdir"
+MEMORY_DIR="$tmpdir"
+OBSERVATIONS_FILE="$tmpdir/observations.md"
+INTEGRITY_SCRIPT="$tmpdir/integrity-check.sh"
+INTEGRITY_PRE_STATE="$tmpdir/pre-dream.json"
+INTEGRITY_ENABLED=true
+INTEGRITY_BLOCK_ON_FLAG=true
+STUB_BLOCK=true
+STUB_LOG="$stub_log"
+export INTEGRITY_ENABLED INTEGRITY_BLOCK_ON_FLAG STUB_BLOCK STUB_LOG
+# Simulate the dream-cycle update-observations integrity block
+touch "\$INTEGRITY_PRE_STATE"
+if [ -f "\$INTEGRITY_SCRIPT" ] && [ "\${INTEGRITY_ENABLED}" = "true" ] && [ -f "\$INTEGRITY_PRE_STATE" ]; then
+  local_exit=0
+  bash "\$INTEGRITY_SCRIPT" dream verify "\$OBSERVATIONS_FILE" "\$INTEGRITY_PRE_STATE" >/dev/null 2>&1 || local_exit=\$?
+  if [ "\$local_exit" -eq 2 ] && [ "\${INTEGRITY_BLOCK_ON_FLAG:-false}" = "true" ]; then
+    exit 2
+  fi
+fi
+exit 0
+WRAPPER
+  chmod +x "$tmpdir/dream-cycle-wrapper.sh"
+  bash "$tmpdir/dream-cycle-wrapper.sh"
+  local wrapper_exit=$?
+  if [ "$wrapper_exit" -eq 2 ]; then
+    echo "  ✅ 17b: exit 2 from verifier propagated through dream-cycle wrapper"
+  else
+    echo "  ❌ 17b: dream-cycle wrapper masked exit 2 (got exit $wrapper_exit)"
+    ok=0
+  fi
+  > "$stub_log"
+
+  # ── Test 17c: --dry-run flag parsed correctly ─────────────────────────────
+  STUB_LOG="$stub_log" INTEGRITY_ENABLED="true" \
+    bash "$tmpdir/integrity-check.sh" dream --dry-run capture "$tmpdir/observations.md" 2>/dev/null
+  if grep -q "dry=true" "$stub_log" 2>/dev/null; then
+    echo "  ✅ 17c: --dry-run flag parsed correctly"
+  else
+    echo "  ❌ 17c: --dry-run flag not detected in argv"
+    ok=0
+  fi
+
+  return $((1 - ok))
+}
+
+if _run_integration_stub_test; then
+  echo "✅ Test 17: execution-level stub tests passed"
+else
+  echo "❌ Test 17: one or more execution-level sub-tests failed"
+  ((FAILURES++))
+fi
+
 # Exit with error code if any tests failed
 if [ "$FAILURES" -gt 0 ]; then
     echo ""

--- a/tests/validate-fixes.sh
+++ b/tests/validate-fixes.sh
@@ -83,11 +83,128 @@ fi
 echo ""
 echo "🎯 Script Validation Complete"
 
+# ─── Integrity verification tests ───────────────────────────────────────────
+
+echo ""
+echo "📋 Test 6: integrity-check.sh exists and is executable"
+if [ -f "scripts/integrity-check.sh" ]; then
+    chmod +x scripts/integrity-check.sh
+    echo "✅ integrity-check.sh present"
+else
+    echo "❌ integrity-check.sh missing"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 7: integrity.yaml config file present"
+if [ -f "config/integrity.yaml" ]; then
+    echo "✅ config/integrity.yaml present"
+else
+    echo "❌ config/integrity.yaml missing"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 8: integrity.yaml has required keys"
+if grep -q 'enabled:' config/integrity.yaml && \
+   grep -q 'sample_n:' config/integrity.yaml && \
+   grep -q 'block_on_flag:' config/integrity.yaml && \
+   grep -q 'reflector_threshold:' config/integrity.yaml && \
+   grep -q 'dream_threshold:' config/integrity.yaml; then
+    echo "✅ integrity.yaml has all required config keys"
+else
+    echo "❌ integrity.yaml missing required keys"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 9: reflector-agent.sh integrates integrity capture + verify"
+if grep -q 'integrity-check.sh' scripts/reflector-agent.sh && \
+   grep -q 'integrity.*pre-reflector\|integrity-pre-reflector' scripts/reflector-agent.sh && \
+   grep -q 'integrity.*verify\|INTEGRITY_RESULT' scripts/reflector-agent.sh; then
+    echo "✅ reflector-agent.sh has integrity capture + verify hooks"
+else
+    echo "❌ reflector-agent.sh missing integrity hooks"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 10: dream-cycle.sh integrates integrity capture in preflight"
+if grep -q 'integrity-check.sh' scripts/dream-cycle.sh && \
+   grep -q 'integrity-pre-dream' scripts/dream-cycle.sh; then
+    echo "✅ dream-cycle.sh preflight has integrity capture hook"
+else
+    echo "❌ dream-cycle.sh missing integrity capture in preflight"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 11: dream-cycle.sh integrates integrity verify in update-observations"
+if grep -q 'integrity: verify post-dream\|integrity_pre_state.*dream\|verify.*integrity.*dream' scripts/dream-cycle.sh; then
+    echo "✅ dream-cycle.sh update-observations has integrity verify hook"
+else
+    echo "❌ dream-cycle.sh missing integrity verify in update-observations"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 12: integrity-check.sh has capture and verify commands"
+if grep -q 'cmd_capture()' scripts/integrity-check.sh && \
+   grep -q 'cmd_verify()' scripts/integrity-check.sh; then
+    echo "✅ integrity-check.sh has capture + verify functions"
+else
+    echo "❌ integrity-check.sh missing capture or verify functions"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 13: integrity-check.sh respects INTEGRITY_ENABLED=false"
+if grep -q 'INTEGRITY_ENABLED.*true' scripts/integrity-check.sh && \
+   grep -q 'disabled.*skipping\|status.*disabled' scripts/integrity-check.sh; then
+    echo "✅ integrity-check.sh respects disabled flag"
+else
+    echo "❌ integrity-check.sh does not handle INTEGRITY_ENABLED=false"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 14: integrity-check.sh has flag-only default (non-blocking)"
+if grep -q 'BLOCK_ON_FLAG.*false\|block_on_flag.*false' scripts/integrity-check.sh && \
+   grep -q 'BLOCK_ON_FLAG.*true' scripts/integrity-check.sh && \
+   grep -q 'exit 2' scripts/integrity-check.sh; then
+    echo "✅ integrity-check.sh is flag-only by default (non-blocking)"
+else
+    echo "❌ integrity-check.sh blocking behavior misconfigured"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 15: cosine similarity uses Python3 (portable float math)"
+if grep -q '_cosine_sim' scripts/integrity-check.sh && \
+   grep -A5 '_cosine_sim()' scripts/integrity-check.sh | grep -q 'python3'; then
+    echo "✅ cosine similarity implemented via python3"
+else
+    echo "❌ cosine similarity not using python3"
+    ((FAILURES++))
+fi
+
+echo ""
+echo "📋 Test 16: dry-run mode supported"
+if grep -q 'dry.run' scripts/integrity-check.sh && \
+   grep -q 'dry.run' scripts/dream-cycle.sh; then
+    echo "✅ dry-run mode supported in both scripts"
+else
+    echo "❌ dry-run mode missing"
+    ((FAILURES++))
+fi
+
 # Exit with error code if any tests failed
 if [ "$FAILURES" -gt 0 ]; then
+    echo ""
     echo "❌ $FAILURES test(s) failed"
     exit 1
 else
+    echo ""
     echo "✅ All tests passed"
     exit 0
 fi


### PR DESCRIPTION
## Summary

Implements the design from issue #18 — semantic drift detection at the two heaviest compression boundaries.

## What's included

**`scripts/integrity-check.sh`** — core verification engine:
- Samples N observations before compression (default: 10, configurable)
- Embeds pre- and post-compression samples using Gemini Embedding 2 (standalone — no Phase 7B dependency as discussed)
- Computes cosine similarity between pre-capture and post-compression pools
- Flags any sample below the configured threshold (default: 0.85)
- Writes to both `memory/integrity-log.md` (tooling target) and the day's dream log (inline visibility)
- **Flag-only by default** (`INTEGRITY_BLOCK_ON_FLAG=false`) — flags are logged but the pipeline continues

**`config/integrity.yaml`** — per-type thresholds pre-wired from day one:
```yaml
thresholds:
  default: 0.85
  reflector_threshold: 0.85  # tune independently once you have calibration data
  dream_threshold: 0.85
```
No code changes needed to tune per-boundary. As you suggested — cheap to add now, high value once data arrives.

**Integration hooks (minimal, non-invasive):**
- `scripts/reflector-agent.sh`: capture right after backup, verify right after atomic write
- `scripts/dream-cycle.sh` preflight: capture before Dream Cycle LLM run
- `scripts/dream-cycle.sh` update-observations: verify after consolidated observations land

**`tests/validate-fixes.sh`** — 11 new tests (Tests 6–16):
All 16 tests pass (5 existing + 11 new).

## Design choices match approved spec

Per the three answers in #18:

1. **Flag-only default** — blocking at 2am would be worse than letting a marginal case through. Log it, review in the morning. Block mode available via `INTEGRITY_BLOCK_ON_FLAG=true` once threshold is calibrated.

2. **Writes to both targets** — inline dream log entry for visibility during normal review + separate `memory/integrity-log.md` for tooling. Both include a machine-parseable HTML comment: `<!-- integrity:reflector ts=... samples=10 flagged=0 min_sim=0.891 -->`

3. **Standalone embedding call now** — no reason to wait on Phase 7B. `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) required; if missing, checks are skipped silently (non-fatal). Phase 7B refactor to reuse cached embeddings is a natural follow-on.

## Failure handling

- Missing `GEMINI_API_KEY`: check skipped silently
- API timeout/error: non-fatal, logged, pipeline continues
- Python3 unavailable: cosine similarity skipped (no hard dependency)
- Pre-capture state missing at verify time: graceful skip

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a memory integrity verification system with configurable sampling, per-checkpoint thresholds, embedding-based similarity checks, dry-run support, and optional blocking-on-flag behavior.
  * Integrated optional pre/post integrity checks into memory processing and update workflows; results are logged and can trigger configurable halt behavior.

* **Tests**
  * Added a test suite validating configuration, CLI capture/verify behavior, dry-run handling, threshold/flag semantics, and blocking exit propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->